### PR TITLE
Renderのスリープ防止設定を追加

### DIFF
--- a/.github/workflows/keep_alive.yml
+++ b/.github/workflows/keep_alive.yml
@@ -1,0 +1,16 @@
+name: Keep Alive Render
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send keep-alive request
+        run: curl -I https://roleplayn.com/


### PR DESCRIPTION
## 概要
Renderの15分間隔のスリープ対策として、GitHub Actionsを利用した「10分間隔の定期実行リクエスト（Keep-alive）」を導入。