### PR TITLE
プライバシーポリシーの問い合わせフォームへのリンクミスを修正

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -127,7 +127,7 @@
             <h4 class="fw-bold mt-5 mb-3 border-bottom pb-2">第11条（お問い合わせ窓口）</h4>
             <p>
               本ポリシーに関するお問い合わせは、本サービス内に設置された
-              <%= link_to "お問い合わせフォーム", new_inquiry_pat, class: "fw-bold text-decoration-underline" %>
+              <%= link_to "お問い合わせフォーム", new_inquiry_path, class: "fw-bold text-decoration-underline" %>
               よりお願いいたします。
             </p>
 


### PR DESCRIPTION
## 概要
プライバシーポリシーページ`privacy.html.erb`の問い合わせフォームへのリンクが`new_inquiry_pat`になっていたため、`new_inquiry_path`に修正。