### PR TITLE
Release v1.1.1　特定環境下でSVG画像がぼやける不具合を解消

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       msgpack (~> 1.2)
     bootstrap (5.3.8)
       popper_js (>= 2.11.8, < 3)
-    brakeman (8.0.2)
+    brakeman (8.0.3)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/assets/stylesheets/components/_logo.scss
+++ b/app/assets/stylesheets/components/_logo.scss
@@ -5,7 +5,6 @@
   margin-top: 5px;
   font-family: var(--font-cinzel);
   font-size: 2em;
-  filter: blur(0.3px);
 
   @include media-breakpoint-down(lg) {
     width: 110px;


### PR DESCRIPTION
## 概要
Release v1.1.0 で実施したロゴの刷新に伴い発生していた、「特定のブラウザ環境（iOS/Safari）での表示不具合」を解消するためのパッチリリースです。

## 変更内容

- **iOS/Safari における描画品質の改善**:
特定環境下（主に iOS 版 Safari）でロゴが極端にぼやけて表示される問題を修正しました。

- **フィルタ設定の廃止**:
描画の「滲み」の原因となっていた filter: blur を削除しました。